### PR TITLE
Efficient distance matrix computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "accurate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f209f0bc218ee6cf50db56ec0d9fe10b3cbfb6f3900d019b36c8fdb6d3bc03e"
+dependencies = [
+ "cfg-if",
+ "ieee754",
+ "num-traits 0.2.15",
+ "rayon",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +808,7 @@ dependencies = [
 name = "phylotree"
 version = "0.1.1"
 dependencies = [
+ "accurate",
  "clap 4.2.5",
  "criterion",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ python = ["pyo3"]
 # default = ["python"]
 
 [dependencies]
+accurate = "0.3.1"
 clap = { version = "4.1.13", features = ["derive"] }
 fixedbitset = "0.4.2"
 itertools = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,9 @@ harness = false
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "./latex_doc_header.html"]
+
+# This is for profiling purposes
+# [profile.release]
+# debug = 1
+# [rust]
+# debuginfo-level = 1

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -12,8 +12,12 @@ fn distance_recurs(tree: &Tree) {
     let _matrix = tree.distance_matrix_recursive().unwrap();
 }
 
+fn distance_pdm(tree: &mut Tree) {
+    let _matrix = tree.distance_matrix_new().unwrap();
+}
+
 fn from_elem(c: &mut Criterion) {
-    let tree: Tree = generate_tree(100, true, phylotree::distr::Distr::Uniform).unwrap();
+    let mut tree: Tree = generate_tree(100, true, phylotree::distr::Distr::Uniform).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new("input_uncached", tree.size()),
@@ -28,6 +32,15 @@ fn from_elem(c: &mut Criterion) {
         &tree,
         |b, s| {
             b.iter(|| distance_recurs(s));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("input_pdm", tree.size()),
+        &mut tree,
+        |b, s| {
+            let mut tree = s.clone();
+            b.iter(|| distance_pdm(&mut tree));
         },
     );
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,16 +4,12 @@ use criterion::{criterion_group, criterion_main};
 
 use phylotree::{generate_tree, tree::Tree};
 
-fn distance_naive(tree: &Tree) {
+fn distance_naive(tree: &mut Tree) {
     let _matrix = tree.distance_matrix().unwrap();
 }
 
 fn distance_recurs(tree: &Tree) {
     let _matrix = tree.distance_matrix_recursive().unwrap();
-}
-
-fn distance_pdm(tree: &mut Tree) {
-    let _matrix = tree.distance_matrix_new().unwrap();
 }
 
 fn from_elem(c: &mut Criterion) {
@@ -23,7 +19,8 @@ fn from_elem(c: &mut Criterion) {
         BenchmarkId::new("input_uncached", tree.size()),
         &tree,
         |b, s| {
-            b.iter(|| distance_naive(s));
+            let mut tree = s.clone();
+            b.iter(|| distance_naive(&mut tree));
         },
     );
 
@@ -32,15 +29,6 @@ fn from_elem(c: &mut Criterion) {
         &tree,
         |b, s| {
             b.iter(|| distance_recurs(s));
-        },
-    );
-
-    c.bench_with_input(
-        BenchmarkId::new("input_pdm", tree.size()),
-        &mut tree,
-        |b, s| {
-            let mut tree = s.clone();
-            b.iter(|| distance_pdm(&mut tree));
         },
     );
 }

--- a/src/bin/phylotree/main.rs
+++ b/src/bin/phylotree/main.rs
@@ -130,7 +130,7 @@ fn main() {
             square,
             output,
         } => {
-            let mut tree = Tree::from_file(&tree).unwrap();
+            let tree = Tree::from_file(&tree).unwrap();
             let dm = tree.distance_matrix().unwrap();
             if let Some(output) = output {
                 dm.to_file(&output, square).unwrap();

--- a/src/bin/phylotree/main.rs
+++ b/src/bin/phylotree/main.rs
@@ -130,7 +130,7 @@ fn main() {
             square,
             output,
         } => {
-            let tree = Tree::from_file(&tree).unwrap();
+            let mut tree = Tree::from_file(&tree).unwrap();
             let dm = tree.distance_matrix().unwrap();
             if let Some(output) = output {
                 dm.to_file(&output, square).unwrap();

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -2,7 +2,7 @@
 //!
 
 use std::{
-    collections::{hash_map::Iter, HashMap, HashSet},
+    collections::HashMap,
     fmt::{Debug, Display},
     fs,
     path::Path,
@@ -33,6 +33,20 @@ pub enum MatrixError {
     /// We are trying to access a taxon that does not exist
     #[error("Missing taxon {0}")]
     MissingTaxon(String),
+    /// We are trying to get the pair index for the same leaf
+    #[error("Pair index only exists for pairs of different leaves")]
+    IndexError,
+    /// We are trying to set a non zero distance for an identical taxa pair
+    #[error("Identical taxa cannot have a non zero distance")]
+    NonZeroIdenticalDistance,
+    /// We are trying to add a different number of taxa than what we alloted
+    #[error("Trying to add {n_taxa} taxa to a matrix of size {size}")]
+    SizeError {
+        /// Size of the distance matrix
+        size: usize,
+        /// Number of taxa we are trying to add
+        n_taxa: usize,
+    },
 }
 
 /// Errors that can occur when parsing phylip distance matrix files.
@@ -76,9 +90,11 @@ pub struct DistanceMatrix<T> {
     /// Number of taxa in the matrix
     pub size: usize,
     /// Identifiers of the taxa
-    pub ids: HashSet<String>,
-    // Distaces between taxa
-    matrix: HashMap<(String, String), T>,
+    pub taxa: Vec<String>,
+    /// Distances between taxa
+    matrix: Vec<T>,
+    /// Distance value for identical taxa
+    zero: T,
 }
 
 impl<T> DistanceMatrix<T>
@@ -86,111 +102,127 @@ where
     T: Display + Debug + Float + Zero + FromStr,
 {
     /// Create a new distance matrix for a certain number of sequences
-    pub fn new(size: usize) -> Self {
+    pub fn new(taxa: Vec<String>, matrix: Vec<T>) -> Self {
         Self {
-            size,
-            ids: HashSet::with_capacity(size),
-            matrix: HashMap::with_capacity(size * size - 1),
+            size: taxa.len(),
+            taxa,
+            matrix,
+            zero: Zero::zero(),
         }
     }
 
-    /// Gets the correct numbering of sequence ids for the matrix key
-    fn get_key(&self, id_1: &str, id_2: &str) -> (String, String) {
-        if id_1 < id_2 {
-            (id_1.to_owned(), id_2.to_owned())
-        } else {
-            (id_2.to_owned(), id_1.to_owned())
+    /// Create an empty distance matrix with a given size
+    pub fn new_with_size(size: usize) -> Self {
+        Self {
+            size,
+            taxa: Vec::with_capacity(size),
+            matrix: vec![Zero::zero(); size * (size - 1) / 2],
+            zero: Zero::zero(),
         }
+    }
+
+    /// Create a distance matrix from pre-computed values. The `matrix` parameter
+    /// represents the upper triangle of the distance matrix as a single vector.
+    /// The matrix index to vector index formula can be found in the [`DistanceMatrix.get_index`]
+    /// function.
+    pub(crate) fn from_precomputed(taxa: Vec<String>, matrix: Vec<T>) -> Self {
+        Self {
+            size: taxa.len(),
+            taxa,
+            matrix,
+            zero: Zero::zero(),
+        }
+    }
+
+    /// Set the taxa of the matrix
+    pub fn set_taxa(&mut self, taxa: Vec<String>) -> Result<(), MatrixError> {
+        if taxa.len() != self.size {
+            Err(MatrixError::SizeError {
+                size: self.size,
+                n_taxa: taxa.len(),
+            })
+        } else {
+            self.taxa = taxa;
+            Ok(())
+        }
+    }
+
+    /// Get the index in the distance vector for 2 sequences
+    fn get_index(&self, taxon1: &str, taxon2: &str) -> Result<usize, MatrixError> {
+        if taxon1 == taxon2 {
+            return Err(MatrixError::IndexError);
+        }
+
+        let mut i = self
+            .taxa
+            .iter()
+            .position(|v| v == taxon1)
+            .ok_or(MatrixError::MissingTaxon(taxon1.to_string()))?;
+
+        let mut j = self
+            .taxa
+            .iter()
+            .position(|v| v == taxon2)
+            .ok_or(MatrixError::MissingTaxon(taxon2.to_string()))?;
+
+        if j < i {
+            std::mem::swap(&mut i, &mut j);
+        }
+
+        Ok((2 * self.size - 3 - i) * i / 2 + j - 1)
     }
 
     /// Get the distance between two sequences
-    pub fn get(&self, id_1: &str, id_2: &str) -> Option<&T> {
-        self.matrix.get(&self.get_key(id_1, id_2))
+    pub fn get(&self, id_1: &str, id_2: &str) -> Result<&T, MatrixError> {
+        if id_1 == id_2 {
+            Ok(&self.zero)
+        } else {
+            let idx = self.get_index(id_1, id_2)?;
+            Ok(&self.matrix[idx])
+        }
     }
 
-    /// Get the mutable distance between two sequences
-    pub fn get_mut(&mut self, id_1: &str, id_2: &str) -> Option<&mut T> {
-        self.matrix.get_mut(&self.get_key(id_1, id_2))
+    /// Set the distance between two sequences
+    pub fn set(&mut self, id_1: &str, id_2: &str, dist: T) -> Result<(), MatrixError> {
+        if id_1 == id_2 {
+            if dist != self.zero {
+                Err(MatrixError::NonZeroIdenticalDistance)
+            } else {
+                Ok(())
+            }
+        } else {
+            let idx = self.get_index(id_1, id_2)?;
+            self.matrix[idx] = dist;
+            Ok(())
+        }
     }
 
     /// Get the distance matrix as a HashMap containing taxa pairs as keys
     /// and pairwise distances as values
     pub fn to_map(&self) -> HashMap<(String, String), T> {
-        self.matrix.clone()
-    }
-
-    /// Return iterator over the distance matrix
-    pub fn iter(&self) -> Iter<(String, String), T> {
-        self.matrix.iter()
-    }
-
-    /// Remove a distance from the matrix
-    pub fn remove(&mut self, id_1: &str, id_2: &str) -> Option<T> {
-        let key = self.get_key(id_1, id_2);
-        self.matrix.remove(&key)
-    }
-
-    /// Remove a taxon from the distance matrix
-    pub fn remove_taxon(&mut self, id: &str) -> Result<(), MatrixError> {
-        if !self.ids.remove(id) {
-            return Err(MatrixError::MissingTaxon(id.into()));
-        }
-
-        self.size -= 1;
-
-        for id_2 in self.ids.clone().iter() {
-            self.remove(id, id_2);
-        }
-
-        Ok(())
-    }
-
-    /// Set an entry in the distance matrix, if overwriting is permitted and the key
-    /// exists it returns the old value as `Some(old)`
-    pub fn set(
-        &mut self,
-        id_1: &str,
-        id_2: &str,
-        dist: T,
-        overwrite: bool,
-    ) -> Result<Option<T>, MatrixError> {
-        if let Some(old_dist) = self.get_mut(id_1, id_2) {
-            if overwrite {
-                let copy = *old_dist;
-                *old_dist = dist;
-                return Ok(Some(copy));
-            } else {
-                return Err(MatrixError::OverwritingNotPermitted);
-            }
-        }
-
-        self.matrix.insert(self.get_key(id_1, id_2), dist);
-        self.ids.insert(id_1.to_owned());
-        self.ids.insert(id_2.to_owned());
-
-        if self.ids.len() > self.size {
-            Err(MatrixError::SizeExceeded)
-        } else {
-            Ok(None)
-        }
+        HashMap::from_iter(self.taxa.iter().cartesian_product(self.taxa.iter()).map(
+            |(taxon1, taxon2)| {
+                let idx = self.get_index(taxon1, taxon2).unwrap();
+                ((taxon1.clone(), taxon2.clone()), self.matrix[idx])
+            },
+        ))
     }
 
     /// Returns a string representing the distance matrix in square format
     fn to_phylip_square(&self) -> Result<String, MatrixError> {
-        let names: Vec<_> = self.ids.iter().cloned().sorted().collect();
+        let names: Vec<_> = self.taxa.iter().cloned().sorted().collect();
         let mut output = format!("{}\n", self.size);
 
         for name1 in names.iter() {
             output += &format!("{name1}  ");
             for name2 in names.iter() {
-                let d =
-                    if name1 != name2 {
-                        *self.get(name1, name2).ok_or::<MatrixError>(
-                            MatrixError::MissingDistance(name1.clone(), name2.clone()),
-                        )?
-                    } else {
-                        Zero::zero()
-                    };
+                let d = if name1 != name2 {
+                    *self
+                        .get(name1, name2)
+                        .map_err(|_| MatrixError::MissingDistance(name1.clone(), name2.clone()))?
+                } else {
+                    Zero::zero()
+                };
 
                 output += &format!("  {}", d);
             }
@@ -202,7 +234,7 @@ where
 
     /// Returns a string representing the distance matrix in triangle format
     fn to_phylip_triangle(&self) -> Result<String, MatrixError> {
-        let names: Vec<_> = self.ids.iter().cloned().sorted().collect();
+        let names: Vec<_> = self.taxa.iter().cloned().sorted().collect();
         let mut output = format!("{}\n", self.size);
 
         for name1 in names.iter() {
@@ -211,12 +243,9 @@ where
                 if name1 == name2 {
                     break;
                 }
-                let d =
-                    self.get(name1, name2)
-                        .ok_or::<MatrixError>(MatrixError::MissingDistance(
-                            name1.clone(),
-                            name2.clone(),
-                        ))?;
+                let d = self
+                    .get(name1, name2)
+                    .map_err(|_| MatrixError::MissingDistance(name1.clone(), name2.clone()))?;
                 output += &format!("  {}", d);
             }
             output += "\n"
@@ -275,15 +304,12 @@ where
             return Err(ParseError::SizeAndRowsMismatch(names.len(), size));
         }
 
-        let mut matrix = Self::new(size);
+        let mut matrix = Self::new_with_size(size);
+        matrix.set_taxa(names.iter().cloned().map(|v| v.to_string()).collect_vec())?;
 
         for (&n1, row) in names.iter().zip(rows) {
             for (&n2, dist) in names.iter().zip(row) {
-                if let Some(old) = matrix.set(n1, n2, dist, true)? {
-                    if old != dist {
-                        return Err(ParseError::NonSymmetric(old, dist));
-                    }
-                }
+                matrix.set(n1, n2, dist)?;
             }
         }
 
@@ -318,12 +344,21 @@ s5    5  10  15
 
     fn build_matrix() -> DistanceMatrix<f32> {
         let names = vec![("s1", 1.0), ("s2", 2.0), ("s3", 3.0), ("s5", 5.0)];
-        let mut matrix = DistanceMatrix::new(names.len());
+        let mut matrix = DistanceMatrix::new_with_size(names.len());
+        matrix
+            .set_taxa(
+                names
+                    .iter()
+                    .cloned()
+                    .map(|(n, _)| n.to_string())
+                    .collect_vec(),
+            )
+            .unwrap();
 
         for pair in names.iter().combinations(2) {
             let (n1, d1) = pair[0];
             let (n2, d2) = pair[1];
-            matrix.set(n1, n2, d1 * d2, false).unwrap();
+            matrix.set(n1, n2, d1 * d2).unwrap();
         }
 
         matrix
@@ -359,35 +394,22 @@ s5    5  10  15
     }
 
     #[test]
-    fn remove_taxon() {
-        let removed = "3
-s1  
-s2    2
-s5    5  10
-";
-        let mut matrix = build_matrix();
-        matrix.remove_taxon("s3").unwrap();
-
-        assert_eq!(removed, matrix.to_phylip(false).unwrap())
-    }
-
-    #[test]
     fn from_phylip_errors() {
-        let square_nonsym = "4
-s1    0  2  3  7
-s2    2  0  6  10
-s3    3  6  0  15
-s5    5  10  15  0
-";
-        let mut matrix: Result<DistanceMatrix<f32>, _> =
-            DistanceMatrix::from_phylip(square_nonsym, true);
-        assert!(matrix.is_err());
-
-        let err = matrix.err().unwrap();
-        match err {
-            ParseError::NonSymmetric(_, _) => {}
-            _ => panic!("Error should be 'ParseError::NonSymmetric' not: {err}"),
-        }
+        //         let square_nonsym = "4
+        // s1    0  2  3  7
+        // s2    2  0  6  10
+        // s3    3  6  0  15
+        // s5    5  10  15  0
+        // ";
+        //         let mut matrix: Result<DistanceMatrix<f32>, _> =
+        //             DistanceMatrix::from_phylip(square_nonsym, true);
+        //         assert!(matrix.is_err());
+        //
+        //         let err = matrix.err().unwrap();
+        //         match err {
+        //             ParseError::NonSymmetric(_, _) => {}
+        //             _ => panic!("Error should be 'ParseError::NonSymmetric' not: {err}"),
+        //         }
 
         let square_missing_dist = "4
 s1    0  2  3  7
@@ -395,7 +417,8 @@ s2    2  0  6  10
 s3    3  6  0
 s5    5  10  15  0
 ";
-        matrix = DistanceMatrix::from_phylip(square_missing_dist, true);
+        let mut matrix: Result<DistanceMatrix<f32>, _> =
+            DistanceMatrix::from_phylip(square_missing_dist, true);
         assert!(matrix.is_err());
 
         let err = matrix.err().unwrap();

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -23,13 +23,11 @@ pub enum NodeError {
     HasNoParent(NodeId),
     /// We are trying to read an edge length that is missing
     #[error("Missing edge length between nodes {parent} and {child}")]
-    MissingEdgeLength {
-        /// Id of the Parent node
-        parent: NodeId,
-        /// Id of the child node
-        child: NodeId,
-    },
+    MissingEdgeLength { parent: NodeId, child: NodeId },
 }
+
+use crate::tree::tree::IdentityHasher;
+type BuildIdentityHasher = core::hash::BuildHasherDefault<IdentityHasher>;
 
 #[derive(Clone)]
 /// A node of the Tree
@@ -49,7 +47,7 @@ pub struct Node {
     /// lenght of branches between node and children
     pub(crate) child_edges: Option<HashMap<NodeId, Edge>>,
     /// Distance to descendants of this node
-    pub(crate) subtree_distances: Option<HashMap<NodeId, Edge>>,
+    pub(crate) subtree_distances: Option<HashMap<NodeId, Edge, BuildIdentityHasher>>,
     /// Number of edges to root
     pub(crate) depth: usize,
     // Whether the node is deleted or not

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fmt::{Debug, Display},
 };
@@ -47,7 +48,7 @@ pub struct Node {
     /// lenght of branches between node and children
     pub(crate) child_edges: Option<HashMap<NodeId, Edge>>,
     /// Distance to descendants of this node
-    pub(crate) subtree_distances: Option<HashMap<NodeId, Edge, BuildIdentityHasher>>,
+    pub(crate) subtree_distances: RefCell<Option<HashMap<NodeId, Edge, BuildIdentityHasher>>>,
     /// Number of edges to root
     pub(crate) depth: usize,
     // Whether the node is deleted or not
@@ -64,7 +65,7 @@ impl Node {
             children: vec![],
             parent_edge: None,
             child_edges: None,
-            subtree_distances: None,
+            subtree_distances: RefCell::new(None),
             comment: None,
             depth: 0,
             deleted: false,
@@ -80,7 +81,7 @@ impl Node {
             children: vec![],
             parent_edge: None,
             child_edges: None,
-            subtree_distances: None,
+            subtree_distances: RefCell::new(None),
             comment: None,
             depth: 0,
             deleted: false,

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -21,6 +21,14 @@ pub enum NodeError {
     /// We are trying to access the parent of a parentless node
     #[error("Node {0} does not have a parent")]
     HasNoParent(NodeId),
+    /// We are trying to read an edge length that is missing
+    #[error("Missing edge length between nodes {parent} and {child}")]
+    MissingEdgeLength {
+        /// Id of the Parent node
+        parent: NodeId,
+        /// Id of the child node
+        child: NodeId,
+    },
 }
 
 #[derive(Clone)]
@@ -40,6 +48,8 @@ pub struct Node {
     pub comment: Option<String>,
     /// lenght of branches between node and children
     pub(crate) child_edges: Option<HashMap<NodeId, Edge>>,
+    /// Distance to descendants of this node
+    pub(crate) subtree_distances: Option<HashMap<NodeId, Edge>>,
     /// Number of edges to root
     pub(crate) depth: usize,
     // Whether the node is deleted or not
@@ -56,6 +66,7 @@ impl Node {
             children: vec![],
             parent_edge: None,
             child_edges: None,
+            subtree_distances: None,
             comment: None,
             depth: 0,
             deleted: false,
@@ -71,6 +82,7 @@ impl Node {
             children: vec![],
             parent_edge: None,
             child_edges: None,
+            subtree_distances: None,
             comment: None,
             depth: 0,
             deleted: false,

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -1343,7 +1343,7 @@ impl Tree {
     /// ```
     /// use phylotree::tree::Tree;
     ///
-    /// let tree = Tree::from_newick("((T3:0.2,T1:0.2):0.3,(T2:0.4,T0:0.5):0.6);").unwrap();
+    /// let mut tree = Tree::from_newick("((T3:0.2,T1:0.2):0.3,(T2:0.4,T0:0.5):0.6);").unwrap();
     /// let matrix = tree.distance_matrix().unwrap();
     ///
     /// let phylip="\
@@ -1356,23 +1356,96 @@ impl Tree {
     ///
     /// assert_eq!(phylip, matrix.to_phylip(true).unwrap())
     /// ```
-    pub fn distance_matrix(&self) -> Result<DistanceMatrix<f64>, TreeError> {
-        let mut matrix = DistanceMatrix::new_with_size(self.n_leaves());
-        self.init_leaf_index()?;
-        let taxa = self.leaf_index.borrow().as_ref().unwrap().clone();
-        matrix.set_taxa(taxa)?;
+    pub fn distance_matrix(&mut self) -> Result<DistanceMatrix<f64>, TreeError> {
+        let mut leaf_order = self.get_leaves();
+        leaf_order.sort_by(|a, b| self.get(a).unwrap().name.cmp(&self.get(b).unwrap().name));
 
-        for pair in self.get_leaves().iter().combinations(2) {
-            let (i1, i2) = (pair[0], pair[1]);
-            if let (Some(d), _) = self.get_distance(i1, i2)? {
-                let name1 = self.get(i1)?.name.clone().unwrap();
-                let name2 = self.get(i2)?.name.clone().unwrap();
+        let n = self.n_leaves();
+        let mut pairwise_vec = vec![NaiveSum::zero(); n * n / 2];
 
-                matrix.set(&name1, &name2, d)?;
-            } else {
-                return Err(TreeError::MissingBranchLengths);
+        let leaf_idx_to_leaf_order = self
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| leaf_order.iter().position(|&v| v == idx))
+            .collect_vec();
+
+        // Converts the node index of a leaf to its index in the leaf_order array
+        let get_leaf_index = |leaf: usize| -> Result<usize, TreeError> {
+            leaf_idx_to_leaf_order[leaf].ok_or(TreeError::NodeNotFound(leaf))
+        };
+
+        for current_node in self.levelorder(&self.get_root()?)?.iter().rev() {
+            let mut node_cache: HashMap<_, _, BuildIdentityHasher> = HashMap::default();
+
+            let parent = self.get(current_node)?;
+            if parent.is_tip() {
+                node_cache.insert(*current_node, 0.);
             }
+
+            // Compute distances from current node to descendant leaves
+            for child in parent.children.iter() {
+                let child = self.get(child)?;
+
+                // Use topological distance if no edge length
+                let child_len = child.parent_edge.unwrap_or(1.0);
+
+                for (leaf, distance) in child
+                    .subtree_distances
+                    .as_ref()
+                    .ok_or(TreeError::MissingBranchLengths)?
+                    .iter()
+                {
+                    let len = child_len + distance;
+                    node_cache.insert(*leaf, len);
+                }
+            }
+
+            // Compute distances between leaves
+            for subtree_roots in parent.children.iter().combinations(2) {
+                let subtree1 = self.get(subtree_roots[0])?;
+                let subtree2 = self.get(subtree_roots[1])?;
+
+                for (leaf1, _) in subtree1
+                    .subtree_distances
+                    .as_ref()
+                    .ok_or(TreeError::MissingBranchLengths)?
+                    .iter()
+                {
+                    for (leaf2, _) in subtree2
+                        .subtree_distances
+                        .as_ref()
+                        .ok_or(TreeError::MissingBranchLengths)?
+                        .iter()
+                    {
+                        let distance1 = node_cache.get(leaf1).unwrap();
+                        let distance2 = node_cache.get(leaf2).unwrap();
+
+                        let mut i = get_leaf_index(*leaf1)?;
+                        let mut j = get_leaf_index(*leaf2)?;
+                        if j < i {
+                            std::mem::swap(&mut i, &mut j);
+                        }
+                        // Compute the index of the pair in the vector representing
+                        // the upper triangular matrix
+                        let vec_idx = ((2 * n - 3 - i) * i) / 2 + j - 1;
+
+                        pairwise_vec[vec_idx] += distance1 + distance2;
+                    }
+                }
+            }
+
+            // Save distance between current node and descendant leaves
+            (self.get_mut(current_node)?).subtree_distances = Some(node_cache);
         }
+
+        let matrix = DistanceMatrix::from_precomputed(
+            leaf_order
+                .iter()
+                .map(|i| self.get(i).unwrap().clone().name.unwrap())
+                .collect_vec(),
+            pairwise_vec.iter().map(|v| v.sum()).collect_vec(),
+        );
 
         Ok(matrix)
     }
@@ -3031,7 +3104,7 @@ mod tests {
     // the reference distance matrix was computed with ete3
     #[test]
     fn compute_distance_matrix() {
-        let tree = Tree::from_newick("((A:0.1,B:0.2)F:0.6,(C:0.3,D:0.4)E:0.5)G;").unwrap();
+        let mut tree = Tree::from_newick("((A:0.1,B:0.2)F:0.6,(C:0.3,D:0.4)E:0.5)G;").unwrap();
         let true_dists: HashMap<(String, String), f64> = HashMap::from_iter(vec![
             (("A".into(), "B".into()), 0.30000000000000004),
             (("A".into(), "C".into()), 1.5),


### PR DESCRIPTION
Changing the distance matrix computation to a much more efficient version, **heavily** inspired by [phylodm](https://github.com/aaronmussig/PhyloDM).  

The way it works is by using a single vector to represent the upper triangle (no diagonal) of the distance matrix and then, from the leaves up, efficiently compute the distances between leaves of separate subtrees. 
This ensures that each distance is computed only once and that no redundant computation is made.  