### PR TITLE
make search_nodes accept capturing closures

### DIFF
--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -271,7 +271,7 @@ impl Tree {
     /// let found = tree.search_nodes(|node| node.name == Some("A".into()));
     /// assert_eq!(found, indices);
     /// ```
-    pub fn search_nodes(self, cond: fn(&Node) -> bool) -> Vec<NodeId> {
+    pub fn search_nodes(self, cond: impl Fn(&Node) -> bool) -> Vec<NodeId> {
         self.nodes
             .iter()
             .filter(|node| cond(node))


### PR DESCRIPTION
Changed the signature so that search_nodes accepts capturing closures. All fn() should still be compatible with this.

