### PR TITLE
Fix Python 3.7-3.10 compatibility by removing tomllib dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,11 @@ __pycache__/
 # C extensions
 *.so
 
+# Pixi
+.pixi/
+pixi.lock
+pixi.toml
+
 # Distribution / packaging
 .Python
 build/

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
-import tomllib as toml
+import re
 
 
 def version():
-    with open("Cargo.toml", "rb") as file:
-        cargo = toml.load(file)
-    return cargo["package"]["version"]
+    with open("Cargo.toml", "r") as file:
+        content = file.read()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if match:
+        return match.group(1)
+    raise ValueError("Could not find version in Cargo.toml")
 
 
 def readme():

--- a/src/python.rs
+++ b/src/python.rs
@@ -88,7 +88,7 @@ impl Tree {
     }
 
     fn is_binary(&self) -> bool {
-        self.tree.is_binary()
+        self.tree.is_binary().unwrap_or(false)
     }
 
     fn is_rooted(&self) -> bool {
@@ -96,7 +96,7 @@ impl Tree {
     }
 
     fn height(&self) -> Option<f64> {
-        self.tree.height()
+        self.tree.height().ok()
     }
 
     fn n_tips(&self) -> usize {
@@ -108,7 +108,7 @@ impl Tree {
     }
 
     fn diameter(&self) -> Option<f64> {
-        self.tree.diameter()
+        self.tree.diameter().ok()
     }
 
     fn n_cherries(&self) -> Result<usize, TreeError> {


### PR DESCRIPTION
The installation recipes/dependencies list Python 3.7 onward, but tomllib is required and only available from Python 3.11+.

Changes:
- Replace tomllib import with regex-based version extraction in setup.py
- Fix PyO3 binding type mismatches (is_binary, height, diameter methods)
- Add pixi environment files to .gitignore

Note:  
Only did the changes in the rust code so I could compile and test it (Tested with Python 3.9 + Rust/PyO3 bindings successfully.)