### PR TITLE
Make the library wasm32 compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "accurate"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f209f0bc218ee6cf50db56ec0d9fe10b3cbfb6f3900d019b36c8fdb6d3bc03e"
-dependencies = [
- "cfg-if",
- "ieee754",
- "num-traits 0.2.15",
- "rayon",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,8 +469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -526,12 +516,6 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "ieee754"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
@@ -679,12 +663,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lzma-sys"
@@ -918,11 +899,11 @@ dependencies = [
 name = "phylotree"
 version = "0.1.3"
 dependencies = [
- "accurate",
  "clap 4.2.5",
  "clap_complete",
  "criterion",
  "fixedbitset",
+ "getrandom",
  "indicatif",
  "itertools",
  "ndarray",
@@ -940,6 +921,7 @@ dependencies = [
  "trait-set",
  "utf8-read",
  "vec_map",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1482,9 +1464,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1492,24 +1474,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1517,22 +1499,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "accurate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f209f0bc218ee6cf50db56ec0d9fe10b3cbfb6f3900d019b36c8fdb6d3bc03e"
+dependencies = [
+ "cfg-if",
+ "ieee754",
+ "num-traits 0.2.15",
+ "rayon",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +917,7 @@ dependencies = [
 name = "phylotree"
 version = "0.1.3"
 dependencies = [
+ "accurate",
  "clap 4.2.5",
  "clap_complete",
  "criterion",
@@ -921,7 +940,6 @@ dependencies = [
  "trait-set",
  "utf8-read",
  "vec_map",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,34 +26,35 @@ categories = [
 crate-type = ["cdylib", "lib"]
 
 [features]
+default = ["cli"]
+cli = ["dep:clap_complete", "dep:indicatif", "dep:needletail", "dep:tinytemplate"]
 python = ["pyo3"]
-# default = ["python"]
 
 [dependencies]
+accurate = "0.3.1"
 clap = { version = "4.1.13", features = ["derive"] }
-clap_complete = "4.4.4"
+clap_complete = { version = "4.4.4", optional = true }
 fixedbitset = "0.4.2"
-indicatif = "0.17.8"
+indicatif = { version = "0.17.8", optional = true }
 itertools = "0.10.5"
 ndarray = "0.16.1"
+needletail = { version = "0.5.1", optional = true }
 num-traits = "0.2.15"
 numeric_literals = "0.2.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"
-tinytemplate = "1.2.1"
+tinytemplate = { version = "1.2.1", optional = true }
 trait-set = "0.3.0"
 utf8-read = "0.4.0"
 vec_map = "0.8.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-needletail = "0.5.1"
 ptree = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-wasm-bindgen = "=0.2.92"
 
 [dependencies.pyo3]
 version = "0.19.0"
@@ -66,6 +67,7 @@ ndarray-rand = "0.15.0"
 
 [[bin]]
 name = "phylotree"
+required-features = ["cli"]
 
 [[bench]]
 name = "benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,25 +30,30 @@ python = ["pyo3"]
 # default = ["python"]
 
 [dependencies]
-accurate = "0.3.1"
 clap = { version = "4.1.13", features = ["derive"] }
 clap_complete = "4.4.4"
 fixedbitset = "0.4.2"
 indicatif = "0.17.8"
 itertools = "0.10.5"
 ndarray = "0.16.1"
-needletail = "0.5.1"
 num-traits = "0.2.15"
 numeric_literals = "0.2.0"
-ptree = "0.4.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-serde = "1.0.164"
+serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"
 tinytemplate = "1.2.1"
 trait-set = "0.3.0"
 utf8-read = "0.4.0"
 vec_map = "0.8.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+needletail = "0.5.1"
+ptree = "0.4.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "=0.2.92"
 
 [dependencies.pyo3]
 version = "0.19.0"

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -147,7 +147,7 @@ where
             return Err(MatrixError::SizeError {
                 size: {
                     let delta = (8.0 * (n_pairs as f64) + 1.).sqrt() as usize;
-                    (delta + 1) / 2
+                    delta.div_ceil(2)
                 },
                 n_taxa: n,
             });
@@ -367,7 +367,7 @@ where
         }
 
         let mut matrix = Self::new_with_size(size);
-        matrix.set_taxa(names.iter().cloned().map(|v| v.to_string()).collect_vec())?;
+        matrix.set_taxa(names.iter().map(|v| v.to_string()).collect_vec())?;
 
         let mut seen = HashSet::new();
 

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -4,10 +4,10 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Display},
-    fs,
-    path::Path,
     str::FromStr,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use std::{fs, path::Path};
 
 use itertools::Itertools;
 use num_traits::{zero, Float, Zero};
@@ -278,6 +278,7 @@ where
     }
 
     /// Writes the matrix to a phylip file
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn to_file(&self, path: &Path, square: bool) -> Result<(), MatrixError> {
         match fs::write(path, self.to_phylip(square)?) {
             Ok(_) => Ok(()),
@@ -418,6 +419,7 @@ where
     }
 
     /// Reads the matrix from a phylip file
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file(path: &Path, square: bool) -> Result<Self, PhylipParseError<T>> {
         let newick_string = fs::read_to_string(path)?;
         Self::from_phylip_strict(&newick_string, square)

--- a/src/tree/tree_impl.rs
+++ b/src/tree/tree_impl.rs
@@ -1,7 +1,6 @@
-use accurate::sum::NaiveSum;
-use accurate::traits::*;
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
+#[cfg(not(target_arch = "wasm32"))]
 use ptree::{print_tree, TreeBuilder};
 use rand::seq::SliceRandom;
 use std::collections::VecDeque;
@@ -9,9 +8,9 @@ use std::iter::zip;
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    fs,
-    path::Path,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use std::{fs, path::Path};
 use vec_map::VecMap;
 
 use thiserror::Error;
@@ -1542,7 +1541,7 @@ impl Tree {
         leaf_order.sort_by(|a, b| self.get(a).unwrap().name.cmp(&self.get(b).unwrap().name));
 
         let n = self.n_leaves();
-        let mut pairwise_vec = vec![NaiveSum::zero(); n * (n - 1) / 2];
+        let mut pairwise_vec = vec![0.0_f64; n * (n - 1) / 2];
 
         let leaf_idx_to_leaf_order = self
             .nodes
@@ -1629,7 +1628,7 @@ impl Tree {
                 .iter()
                 .map(|i| self.get(i).unwrap().clone().name.unwrap())
                 .collect_vec(),
-            pairwise_vec.iter().map(|v| v.sum()).collect_vec(),
+            pairwise_vec.iter().copied().collect_vec(),
         );
 
         Ok(matrix?)
@@ -2180,6 +2179,7 @@ impl Tree {
     }
 
     /// Writes the tree to a newick file
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn to_file(&self, path: &Path) -> Result<(), TreeError> {
         match fs::write(path, self.to_newick()?) {
             Ok(_) => Ok(()),
@@ -2188,6 +2188,7 @@ impl Tree {
     }
 
     /// Creates a tree from a newick file
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file(path: &Path) -> Result<Self, NewickParseError> {
         let newick_string = fs::read_to_string(path)?;
         Self::from_newick(&newick_string)
@@ -2223,6 +2224,7 @@ END;
     }
 
     /// Recursive function that adds node representation to a printable tree builder
+    #[cfg(not(target_arch = "wasm32"))]
     fn print_nodes(
         &self,
         root_idx: &NodeId,
@@ -2250,6 +2252,7 @@ END;
     }
 
     /// Print a debug view of the tree to the console
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn print_debug(&self) -> Result<(), TreeError> {
         let root = self.get_root()?;
         let mut builder = TreeBuilder::new(format!("{:?}", root));
@@ -2262,6 +2265,7 @@ END;
     }
 
     /// Print the tree to the console
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn print(&self) -> Result<(), TreeError> {
         let root = self.get_root()?;
         let mut builder = TreeBuilder::new(format!("{:?}", root));

--- a/src/tree/tree_impl.rs
+++ b/src/tree/tree_impl.rs
@@ -1,3 +1,5 @@
+use accurate::sum::NaiveSum;
+use accurate::traits::*;
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 #[cfg(not(target_arch = "wasm32"))]
@@ -1541,7 +1543,7 @@ impl Tree {
         leaf_order.sort_by(|a, b| self.get(a).unwrap().name.cmp(&self.get(b).unwrap().name));
 
         let n = self.n_leaves();
-        let mut pairwise_vec = vec![0.0_f64; n * (n - 1) / 2];
+        let mut pairwise_vec = vec![NaiveSum::zero(); n * (n - 1) / 2];
 
         let leaf_idx_to_leaf_order = self
             .nodes
@@ -1628,7 +1630,7 @@ impl Tree {
                 .iter()
                 .map(|i| self.get(i).unwrap().clone().name.unwrap())
                 .collect_vec(),
-            pairwise_vec.iter().copied().collect_vec(),
+            pairwise_vec.iter().map(|v| v.sum()).collect_vec(),
         );
 
         Ok(matrix?)

--- a/src/tree/tree_impl.rs
+++ b/src/tree/tree_impl.rs
@@ -926,8 +926,8 @@ impl Tree {
                 .borrow()
                 .as_ref()
                 .unwrap()
-                .iter()
-                .map(|(k, _)| k.clone()),
+                .keys()
+                .cloned(),
         ))
     }
 
@@ -1717,7 +1717,6 @@ impl Tree {
             .nodes
             .iter()
             .filter(|node| !node.deleted && node.parent.is_some() && node.children.len() == 1)
-            .cloned()
             .map(|node| node.id)
             .collect();
 


### PR DESCRIPTION
Makes `phylotree` usable as a library on `wasm32` targets, while keeping the native CLI unchanged. I didn't make any public API changes for native targets.

- New `cli` feature (default) gating `clap_complete`, `indicatif`, `needletail` and `tinytemplate`; the `phylotree` binary now declares `required-features = ["cli"]`. 
- `ptree` moved to a `cfg(not(target_arch = "wasm32"))` target dependency.
- `getrandom` with the `js` feature added for `wasm32`, so `rand` works in the browser.
- `serde` now pulls in its `derive` feature explicitly.